### PR TITLE
Fix chown usage in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -150,7 +150,7 @@ fi
 
 if [[ "$CREATE_LARAVEL_STORAGE" == "1" ]] ; then
   mkdir -p /var/www/html/storage/{logs,app/public,framework/{cache/data,sessions,testing,views}}
-  chown -Rf nginx.nginx /var/www/html/storage
+  chown -Rf nginx:nginx /var/www/html/storage
   adduser -s /bin/bash -g 82 -D sail
 fi
 


### PR DESCRIPTION
I found the warning message in docker log

    chown: warning: '.' should be ':': ‘nginx.nginx’